### PR TITLE
Update driver_ir_remote.c

### DIFF
--- a/src/driver_ir_remote.c
+++ b/src/driver_ir_remote.c
@@ -150,6 +150,8 @@ static void a_ir_remote_nec_repeat_decode(ir_remote_handle_t *handle)
         data.status = IR_REMOTE_STATUS_REPEAT;                                            /* frame invalid */
         handle->receive_callback(&data);                                                  /* run the callback */
     }
+    /* 关键：为了让下一次4个边沿再次触发repeat解码 */
+    handle->decode_len = 0;   // <<< 新增这一行
 }
 
 /**


### PR DESCRIPTION
修复repeat不能正确的多次重复触发

## PR fix

IR_REMOTE_STATUS_REPEAT只会触发一次

## PR change and describe

在 a_ir_remote_nec_repeat_decode() 成功回调后立刻清空缓存：

/* 成功时 */
if (handle->receive_callback != NULL)
{
    data.address = handle->last_code.address;
    data.command = handle->last_code.command;
    data.status  = IR_REMOTE_STATUS_REPEAT;
    handle->receive_callback(&data);
}

/* 关键：为了让下一次4个边沿再次触发repeat解码 */
handle->decode_len = 0;   // <<< 新增这一行